### PR TITLE
fix: Digital wellbeing not being launched

### DIFF
--- a/app/src/main/java/com/zenlauncher/helpers/AppUtils.kt
+++ b/app/src/main/java/com/zenlauncher/helpers/AppUtils.kt
@@ -12,6 +12,10 @@ import androidx.core.content.edit
 import androidx.core.net.toUri
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.zenlauncher.AppInfo
+import com.zenlauncher.helpers.Constants.DIGITAL_WELLBEING_ACTIVITY
+import com.zenlauncher.helpers.Constants.DIGITAL_WELLBEING_PACKAGE_NAME
+import com.zenlauncher.helpers.Constants.DIGITAL_WELLBEING_SAMSUNG_ACTIVITY
+import com.zenlauncher.helpers.Constants.DIGITAL_WELLBEING_SAMSUNG_PACKAGE_NAME
 
 object AppUtils {
 
@@ -65,9 +69,21 @@ object AppUtils {
         }
     }
 
+
     fun launchApp(context: Context, app: AppInfo) {
-        val intent = Intent().apply {
-            setClassName(app.packageName, app.className)
+        val (packageName, className) = when (app.packageName) {
+            DIGITAL_WELLBEING_PACKAGE_NAME -> {
+                DIGITAL_WELLBEING_PACKAGE_NAME to DIGITAL_WELLBEING_ACTIVITY
+            }
+            DIGITAL_WELLBEING_SAMSUNG_PACKAGE_NAME -> {
+                DIGITAL_WELLBEING_SAMSUNG_PACKAGE_NAME to DIGITAL_WELLBEING_SAMSUNG_ACTIVITY
+            }
+            else -> app.packageName to app.className
+        }
+
+        val intent = Intent(Intent.ACTION_MAIN).apply {
+            setClassName(packageName, className)
+            addCategory(Intent.CATEGORY_LAUNCHER)
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
         context.startActivity(intent)

--- a/app/src/main/java/com/zenlauncher/helpers/Constants.kt
+++ b/app/src/main/java/com/zenlauncher/helpers/Constants.kt
@@ -7,6 +7,11 @@ object Constants {
 
     const val GITHUB_REPO = "https://github.com/santhoshmani1/Zenlaunch"
 
+    const val DIGITAL_WELLBEING_PACKAGE_NAME = "com.google.android.apps.wellbeing"
+    const val DIGITAL_WELLBEING_ACTIVITY = "com.google.android.apps.wellbeing.settings.TopLevelSettingsActivity"
+    const val DIGITAL_WELLBEING_SAMSUNG_PACKAGE_NAME = "com.samsung.android.forest"
+    const val DIGITAL_WELLBEING_SAMSUNG_ACTIVITY = "com.samsung.android.forest.launcher.LauncherActivity"
+
     object Intents {
         const val SHARE_VIA = "Share via"
         const val DEVICE_ADMIN_INFO = "Enable Zen Launcher double-tap to lock"

--- a/app/src/main/java/com/zenlauncher/ui/components/settings/SettingsComponents.kt
+++ b/app/src/main/java/com/zenlauncher/ui/components/settings/SettingsComponents.kt
@@ -1,20 +1,47 @@
 package com.zenlauncher.ui.components.settings
 
+import android.content.Context
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.zenlauncher.helpers.Constants
+import com.zenlauncher.helpers.SettingsUtils
 
 @Composable
 fun SettingsOption(text: String, onClick: () -> Unit) {
@@ -45,5 +72,87 @@ fun SettingsHeader(text: String) {
             fontWeight = FontWeight.Bold,
             color = Color.White
         )
+    }
+}
+
+@Composable
+fun ExitZenLauncherDialog(
+    context: Context,
+    onDismiss: () -> Unit
+) {
+    var showSecondStep by remember { mutableStateOf(false) }
+
+    val title = if (showSecondStep) "Select Default Launcher" else "Exit Zen Launcher"
+    val message = if (showSecondStep)
+        "To exit, please select another Home screen app as your default launcher."
+    else
+        "Are you sure you want to exit Zen Launcher?"
+    val buttonText = if (showSecondStep) "Open Settings" else "Exit"
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.5f))
+            .clickable(onClick = onDismiss),
+        contentAlignment = Alignment.Center
+    ) {
+        AnimatedVisibility(
+            visible = true,
+            enter = fadeIn() + scaleIn(),
+            exit = fadeOut() + scaleOut()
+        ) {
+            Card(
+                shape = RoundedCornerShape(24.dp),
+                colors = CardDefaults.cardColors(containerColor = Color(0xFF121212).copy(alpha = 0.95f)),
+                modifier = Modifier
+                    .padding(24.dp)
+                    .wrapContentHeight()
+                    .widthIn(max = 340.dp)
+            ) {
+                Column(
+                    modifier = Modifier.padding(24.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        text = title,
+                        fontSize = 22.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White,
+                        textAlign = TextAlign.Center
+                    )
+
+                    Text(
+                        text = message,
+                        fontSize = 16.sp,
+                        color = Color.LightGray,
+                        textAlign = TextAlign.Center
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        TextButton(onClick = onDismiss) {
+                            Text("Cancel", color = Color.White)
+                        }
+                        Button(
+                            onClick = {
+                                if (showSecondStep) {
+                                    SettingsUtils.openDefaultLauncherSettings(context)
+                                } else {
+                                    showSecondStep = true
+                                }
+                            },
+                            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF069AED)),
+                            shape = RoundedCornerShape(12.dp)
+                        ) {
+                            Text(buttonText, color = Color.White)
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/zenlauncher/ui/screens/SettingsActivity.kt
+++ b/app/src/main/java/com/zenlauncher/ui/screens/SettingsActivity.kt
@@ -1,6 +1,7 @@
 package com.zenlauncher.ui.screens
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Arrangement
@@ -12,6 +13,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -19,6 +24,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.zenlauncher.helpers.Constants
 import com.zenlauncher.helpers.SettingsUtils
+import com.zenlauncher.ui.components.settings.ExitZenLauncherDialog
 import com.zenlauncher.ui.components.settings.SettingsHeader
 import com.zenlauncher.ui.components.settings.SettingsOption
 import com.zenlauncher.ui.components.settings.ZenTopAppBar
@@ -37,6 +43,7 @@ class SettingsActivity : ComponentActivity() {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ZenLauncherSettingsScreen(onBackPressed: () -> Unit) {
+    var showExitDialog by remember { mutableStateOf(false) }
     val context = LocalContext.current
     Scaffold(
         topBar = {
@@ -91,8 +98,16 @@ fun ZenLauncherSettingsScreen(onBackPressed: () -> Unit) {
             Spacer(modifier = Modifier.height(Constants.Settings.SPACING_LARGE.dp))
 
             SettingsOption("Exit Zen Launcher") {
-                (context as? ComponentActivity)?.finishAffinity()
+                showExitDialog = true
             }
+        }
+
+        if (showExitDialog) {
+            Log.d("Exiting", "Here we go")
+            ExitZenLauncherDialog(
+                context = context,
+                onDismiss = { showExitDialog = false }
+            )
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when launching Digital Wellbeing apps, including support for both Google and Samsung versions.

* **New Features**
  * Added a two-step confirmation dialog for exiting Zen Launcher, guiding users to select a default launcher.

* **Chores**
  * Added new internal constants for Digital Wellbeing app package and activity names to enhance app handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->